### PR TITLE
metrics: fix register version

### DIFF
--- a/pkg/apis/metrics/v1alpha2/register.go
+++ b/pkg/apis/metrics/v1alpha2/register.go
@@ -12,7 +12,7 @@ import (
 // the name of the group and the version of the API
 var SchemeGroupVersion = schema.GroupVersion{
 	Group:   metrics.GroupName,
-	Version: "v1alpha1",
+	Version: "v1alpha2",
 }
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind


### PR DESCRIPTION
fixes panic when creating the metrics client, see error below:
```
panic: Double registration of different types for metrics.smi-spec.io/v1alpha1, Kind=TrafficMetrics: old=github.com/servicemeshinterface/smi-sdk-go/pkg/apis/metrics/v1alpha1.TrafficMetrics, new=github.com/servicemeshinterface/smi-sdk-go/pkg/apis/metrics/v1alpha2.TrafficMetrics in scheme "pkg/runtime/scheme.go:101"

```