### PR TITLE
Change TrafficTarget Port definition to match spec

### DIFF
--- a/pkg/apis/access/v1alpha1/traffic_target.go
+++ b/pkg/apis/access/v1alpha1/traffic_target.go
@@ -51,7 +51,7 @@ type IdentityBindingSubject struct {
 	// Namespace where the Subject is deployed
 	Namespace string `json:"namespace,omitempty"`
 	// Port defines a TCP port to apply the TrafficTarget to
-	Port string `json:"port,omitempty"`
+	Port int `json:"port,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
According to our spec, Port should be a number, not a string.

https://github.com/servicemeshinterface/smi-sdk-go/blob/master/crds/access.yaml#L44

