### PR TITLE
Port on a traffic target is not requried

### DIFF
--- a/crds/access.yaml
+++ b/crds/access.yaml
@@ -28,7 +28,6 @@ spec:
           required:
             - name
             - kind
-            - port
           properties:
             kind:
               description: Kind of the destination.


### PR DESCRIPTION
According to our [spec](https://github.com/servicemeshinterface/smi-spec/blob/master/traffic-access-control.md#traffictarget-v1alpha1), Port is not a requirement for the `TrafficTarget` Destination

> port is an optional element, if not specified, traffic will be allowed to all ports on the destination service.

Signed-off-by: Manuel Zapf <manuel@containo.us>