### PR TITLE
Fix TrafficTarget v1alpha2 Spec type

### DIFF
--- a/pkg/apis/access/v1alpha2/traffic_target.go
+++ b/pkg/apis/access/v1alpha2/traffic_target.go
@@ -22,7 +22,7 @@ type TrafficTarget struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec []TrafficTargetSpec `json:"spec"`
+	Spec TrafficTargetSpec `json:"spec"`
 }
 
 // TrafficTargetSpec is the specification of a TrafficTarget

--- a/pkg/apis/access/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/access/v1alpha2/zz_generated.deepcopy.go
@@ -48,13 +48,7 @@ func (in *TrafficTarget) DeepCopyInto(out *TrafficTarget) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.Spec != nil {
-		in, out := &in.Spec, &out.Spec
-		*out = make([]TrafficTargetSpec, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
+	in.Spec.DeepCopyInto(&out.Spec)
 	return
 }
 


### PR DESCRIPTION
TrafficTarget v1alpha2 defines the `Spec` attribute as a slice of `TrafficTargetSpec`. This is inconsistent with the specification
as it should just be a `TrafficTargetSpec`, not a slice.

This PR replaces the `[]TrafficTargetSpec` by a `TrafficTargetSpec` in the TrafficTarget v1alpha2 type.

Fixes #83 